### PR TITLE
Added functions for lower bounds to Python interface. These are expressed as minimums on edges.

### DIFF
--- a/src/pylmcf/cpp/pylmcf/graph.hpp
+++ b/src/pylmcf/cpp/pylmcf/graph.hpp
@@ -56,6 +56,7 @@ private:
     const lemon::StaticDigraph lemon_graph;
     lemon::StaticDigraph::NodeMap<T> node_supply_map;
     lemon::StaticDigraph::ArcMap<T> capacities_map;
+    lemon::StaticDigraph::ArcMap<T> minimums_map;
     lemon::StaticDigraph::ArcMap<T> costs_map;
 
     lemon::NetworkSimplex<lemon::StaticDigraph, T, T> solver;
@@ -71,6 +72,7 @@ public:
         lemon_graph(make_lemon_graph(no_nodes, edge_starts, edge_ends)),
         node_supply_map(lemon_graph),
         capacities_map(lemon_graph),
+        minimums_map(lemon_graph),
         costs_map(lemon_graph),
         solver(lemon_graph)
         {};
@@ -132,12 +134,36 @@ public:
         _solved = false;
     }
 
+    void set_edge_minimums(const std::span<T> &minimums) {
+        if (minimums.size() != static_cast<size_t>(no_edges()))
+            throw std::invalid_argument("Minimums must have the same size as the number of edges");
+
+        for (LEMON_INT ii = 0; ii < no_edges(); ii++)
+        {
+            // std::cerr << "Setting minimum " << minimums[ii] << " for edge " << ii << std::endl;
+            minimums_map[lemon_graph.arcFromId(ii)] = minimums[ii];
+        }
+
+        solver.lowerMap(minimums_map);
+        _solved = false;
+    }
+
     // Caller must free() the returned span's data.
     std::span<T> get_edge_capacities() const {
         T* data = static_cast<T*>(malloc(sizeof(T) * no_edges()));
         for (LEMON_INT ii = 0; ii < no_edges(); ii++)
         {
             data[ii] = capacities_map[lemon_graph.arcFromId(ii)];
+        }
+        return std::span<T>(data, no_edges());
+    }
+
+    // Caller must free() the returned span's data.
+    std::span<T> get_edge_minimums() const {
+        T* data = static_cast<T*>(malloc(sizeof(T) * no_edges()));
+        for (LEMON_INT ii = 0; ii < no_edges(); ii++)
+        {
+            data[ii] = minimums_map[lemon_graph.arcFromId(ii)];
         }
         return std::span<T>(data, no_edges());
     }
@@ -205,7 +231,9 @@ public:
         std::string out = "Graph with " + std::to_string(no_nodes()) + " nodes and " + std::to_string(no_edges()) + " edges\n";
         out += "Edges:\n";
         for (LEMON_INT ii = 0; ii < no_edges(); ii++) {
-            out += "  " + std::to_string(lemon_graph.id(lemon_graph.source(lemon_graph.arcFromId(ii)))) + " -> " + std::to_string(lemon_graph.id(lemon_graph.target(lemon_graph.arcFromId(ii)))) + " with cost " + std::to_string(costs_map[lemon_graph.arcFromId(ii)]) + " and capacity " + std::to_string(capacities_map[lemon_graph.arcFromId(ii)]) + "\n";
+            out += "  " + std::to_string(lemon_graph.id(lemon_graph.source(lemon_graph.arcFromId(ii)))) + " -> " + std::to_string(lemon_graph.id(lemon_graph.target(lemon_graph.arcFromId(ii)))) + " with cost " + std::to_string(costs_map[lemon_graph.arcFromId(ii)]) +
+            " and capacity " + std::to_string(capacities_map[lemon_graph.arcFromId(ii)]) +
+            " and minimum " + std::to_string(minimums_map[lemon_graph.arcFromId(ii)]) + "\n";
         }
         // for (size_t ii = 0; ii < no_edges(); ii++) {
         //     out += "  " + std::to_string(edges_starts[ii]) + " -> " + std::to_string(edges_ends[ii]) + " with cost " + std::to_string(costs[ii]) + "\n";
@@ -226,6 +254,10 @@ public:
         set_edge_capacities(numpy_to_span(capacities));
     }
 
+    void set_edge_minimums_py(const nb::ndarray<T, nb::shape<-1>> &minimums) {
+        set_edge_minimums(numpy_to_span(minimums));
+    }
+
     void set_edge_costs_py(const nb::ndarray<T, nb::shape<-1>> &costs) {
         set_edge_costs(numpy_to_span(costs));
     }
@@ -236,6 +268,10 @@ public:
 
     nb::ndarray<T, nb::numpy, nb::shape<-1>> get_edge_capacities_py() const {
         return steal_mallocd_span_to_np_array(get_edge_capacities());
+    }
+
+    nb::ndarray<T, nb::numpy, nb::shape<-1>> get_edge_minimums_py() const {
+        return steal_mallocd_span_to_np_array(get_edge_minimums());
     }
 
     nb::ndarray<T, nb::numpy, nb::shape<-1>> get_edge_costs_py() const {

--- a/src/pylmcf/cpp/pylmcf/lmcf.hpp
+++ b/src/pylmcf/cpp/pylmcf/lmcf.hpp
@@ -23,13 +23,14 @@ T lmcf(
     std::span<T> edges_starts,
     std::span<T> edges_ends,
     std::span<T> capacities,
+    std::span<T> minimums,
     std::span<T> costs,
     std::span<T> result
     )
     requires std::is_signed<T>::value && std::is_integral<T>::value
     {
     // Make sure all edge arrays and result are the same size
-    if (edges_starts.size() != edges_ends.size() || edges_starts.size() != capacities.size() || edges_starts.size() != costs.size() || edges_starts.size() != result.size()) {
+    if (edges_starts.size() != edges_ends.size() || edges_starts.size() != capacities.size() || edges_starts.size() != minimums.size() || edges_starts.size() != costs.size() || edges_starts.size() != result.size()) {
         throw std::invalid_argument("All edge arrays and result must be the same size");
     }
 
@@ -43,6 +44,9 @@ T lmcf(
         }
         if (capacities[i] < 0) {
             throw std::invalid_argument("Capacities must be non-negative");
+        }
+        if (minimums[i] < 0) {
+            throw std::invalid_argument("Minimums must be non-negative");
         }
         if (costs[i] < 0) {
             throw std::invalid_argument("Costs must be non-negative");
@@ -62,11 +66,13 @@ T lmcf(
     for (size_t i = 0; i < no_edges; i++)
         arcs.push_back(graph.addArc(nodes[edges_starts[i]], nodes[edges_ends[i]]));
 
-    // Add capacities and costs to the arcs
+    // Add capacities and minimums and costs to the arcs
     lemon::ListDigraph::ArcMap<T> capacities_map(graph);
+    lemon::ListDigraph::ArcMap<T> minimums_map(graph);
     lemon::ListDigraph::ArcMap<T> costs_map(graph);
     for (size_t i = 0; i < no_edges; i++) {
         capacities_map[arcs[i]] = capacities[i];
+        minimums_map[arcs[i]] = minimums[i];
         costs_map[arcs[i]] = costs[i];
     }
 
@@ -80,6 +86,7 @@ T lmcf(
 
     // Run the solver
     solver.upperMap(capacities_map);
+    solver.lowerMap(minimums_map);
     solver.costMap(costs_map);
     solver.supplyMap(node_supply_map);
     auto status = solver.run();

--- a/src/pylmcf/cpp/pylmcf/pylmcf.cpp
+++ b/src/pylmcf/cpp/pylmcf/pylmcf.cpp
@@ -23,17 +23,19 @@ nb::ndarray<T, nb::numpy, nb::shape<-1>> py_lmcf(
     nb::ndarray<T, nb::shape<-1>> edges_starts,
     nb::ndarray<T, nb::shape<-1>> edges_ends,
     nb::ndarray<T, nb::shape<-1>> capacities,
+    nb::ndarray<T, nb::shape<-1>> minimums,
     nb::ndarray<T, nb::shape<-1>> costs
     ) {
     auto node_supply_span = numpy_to_span<T>(node_supply);
     auto edges_starts_span = numpy_to_span<T>(edges_starts);
     auto edges_ends_span = numpy_to_span<T>(edges_ends);
     auto capacities_span = numpy_to_span<T>(capacities);
+    auto minimums_span = numpy_to_span<T>(minimums);
     auto costs_span = numpy_to_span<T>(costs);
 
     nb::ndarray<T, nb::numpy, nb::shape<-1>> result = create_empty_numpy_array<T>(edges_starts_span.size());
     std::span<T> result_span(static_cast<T*>(result.data()), result.shape(0));
-    lmcf(node_supply_span, edges_starts_span, edges_ends_span, capacities_span, costs_span, result_span);
+    lmcf(node_supply_span, edges_starts_span, edges_ends_span, capacities_span, minimums_span, costs_span, result_span);
 
     return result;
 }
@@ -56,6 +58,8 @@ NB_MODULE(pylmcf_cpp, m) {
         .def("get_node_supply", &Graph<int64_t>::get_node_supply_py)
         .def("set_edge_capacities", &Graph<int64_t>::set_edge_capacities_py)
         .def("get_edge_capacities", &Graph<int64_t>::get_edge_capacities_py)
+        .def("set_edge_minimums", &Graph<int64_t>::set_edge_minimums_py)
+        .def("get_edge_minimums", &Graph<int64_t>::get_edge_minimums_py)
         .def("set_edge_costs", &Graph<int64_t>::set_edge_costs_py)
         .def("get_edge_costs", &Graph<int64_t>::get_edge_costs_py)
         .def("solve", &Graph<int64_t>::solve)

--- a/tests/graph_lb.py
+++ b/tests/graph_lb.py
@@ -1,0 +1,25 @@
+from pylmcf.graph import Graph
+import numpy as np
+
+
+def test_graph_simple():
+    G = Graph(3, np.array([0, 0, 1]), np.array([1, 2, 2]))
+    G.set_edge_costs(np.array([1, 3, 5]))
+    G.set_edge_capacities(np.array([3, 3, 5]))
+    # G.set_edge_minimums(np.array([3, 0, 0]))
+    G.set_node_supply(np.array([5, 0, -5]))
+    # G.show()
+    G.solve()
+    # assert all(G.result() == np.array([2, 3, 2]))
+    # assert G.total_cost() == 21
+    print(G.result())
+    print(G.total_cost())
+
+    G.set_edge_minimums(np.array([3, 0, 0]))
+    G.solve()
+    print(G.result())
+    print(G.total_cost())
+
+
+if __name__ == "__main__":
+    test_graph_simple()


### PR DESCRIPTION
This code mimics the code for edge capacities and calls the lowerMap (instead of upperMap) within the LEMON code base.

I am working on a network optimization project that uses lower bounds on arcs. While it is possible to mimic the behavior of lower bounds by adjusting supply/rhs of nodes, we are comparing solutions to another solver and want to replicate the existing model formulation exactly.

I see that the LEMON solver supports lower bounds with the lowerMap function. I added the functions corresponding to upper bounds (edge capacities) to allow the option for lower bounds. 

I have tested adding lower bounds with set_edge_minimums and solving to validate that they work as expected. I also tested retrieving the array of lower bounds with get_edge_minimums.

I would like to add these functions to the existing pylmcf package so others can use them and so they become a consistent part of future versions.

Please let me know if this is possible. Also, I can update the inline documentation if needed to reflect the changes for lower bounds.  